### PR TITLE
chore: release v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/sayanarijit/cottage/compare/v0.1.8...v0.1.9) - 2026-05-03
+
+### Other
+
+- Update logo image format in README.md
+- Remove logo
+- Document examples and logo updates
+
 ## [0.1.8](https://github.com/sayanarijit/cottage/compare/v0.1.7...v0.1.8) - 2026-05-03
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cottage"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cottage"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2024"
 description = "A modern git based age-encrypted secrets manager for teams."
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `cottage`: 0.1.8 -> 0.1.9 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.9](https://github.com/sayanarijit/cottage/compare/v0.1.8...v0.1.9) - 2026-05-03

### Other

- Update logo image format in README.md
- Remove logo
- Document examples and logo updates
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).