### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/sayanarijit/cottage/compare/v0.1.10...v0.2.0) - 2026-05-04
+
+### Other
+
+- --dry-run, --skip-encryption, --skip-decryption
+- Don't allow `run` on dirty paths
+- Clarify encryption behavior in README
+
 ## [0.1.10](https://github.com/sayanarijit/cottage/compare/v0.1.9...v0.1.10) - 2026-05-03
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cottage"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cottage"
-version = "0.1.10"
+version = "0.2.0"
 edition = "2024"
 description = "A modern git based age-encrypted secrets manager for teams."
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `cottage`: 0.1.10 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `cottage` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field DecryptOptions.dry_run in /tmp/.tmpPjhTbv/cottage/src/dec.rs:23
  field SyncOptions.skip_encryption in /tmp/.tmpPjhTbv/cottage/src/sync.rs:17
  field SyncOptions.skip_decryption in /tmp/.tmpPjhTbv/cottage/src/sync.rs:18
  field SyncOptions.dry_run in /tmp/.tmpPjhTbv/cottage/src/sync.rs:22
  field EncryptOptions.dry_run in /tmp/.tmpPjhTbv/cottage/src/enc.rs:32
  field DiffOptions.skip_encryption in /tmp/.tmpPjhTbv/cottage/src/diff.rs:13
  field DiffOptions.skip_decryption in /tmp/.tmpPjhTbv/cottage/src/diff.rs:14

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  cottage::remove_line_if_present now takes 3 parameters instead of 2, in /tmp/.tmpPjhTbv/cottage/src/project.rs:270
  cottage::status_path now takes 2 parameters instead of 1, in /tmp/.tmpPjhTbv/cottage/src/status.rs:113
  cottage::append_to_gitignore_if_absent now takes 2 parameters instead of 1, in /tmp/.tmpPjhTbv/cottage/src/project.rs:345
  cottage::remove_from_gitignore_if_present now takes 2 parameters instead of 1, in /tmp/.tmpPjhTbv/cottage/src/project.rs:359
  cottage::append_line_if_absent now takes 3 parameters instead of 2, in /tmp/.tmpPjhTbv/cottage/src/project.rs:224
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/sayanarijit/cottage/compare/v0.1.10...v0.2.0) - 2026-05-04

### Other

- --dry-run, --skip-encryption, --skip-decryption
- Don't allow `run` on dirty paths
- Clarify encryption behavior in README
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).