### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/sayanarijit/cottage/compare/v0.1.10...v0.2.0) - 2026-05-04
+
+### Other
+
+- Privatize crates, fix tests
+- Use secrecy types
+- Document
+- Make things private
+- --dry-run, --skip-encryption, --skip-decryption
+- Don't allow `run` on dirty paths
+- Clarify encryption behavior in README
+
 ## [0.1.10](https://github.com/sayanarijit/cottage/compare/v0.1.9...v0.1.10) - 2026-05-03
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cottage"
-version = "0.1.10"
+version = "0.2.0"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cottage"
-version = "0.1.10"
+version = "0.2.0"
 edition = "2024"
 description = "A modern git based age-encrypted secrets manager for teams."
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `cottage`: 0.1.10 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `cottage` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum cottage::DecryptionMode, previously in file /tmp/.tmpreH52A/cottage/src/dec.rs:15
  enum cottage::OperationKind, previously in file /tmp/.tmpreH52A/cottage/src/operation.rs:4
  enum cottage::EncryptionMode, previously in file /tmp/.tmpreH52A/cottage/src/enc.rs:17
  enum cottage::Recipient, previously in file /tmp/.tmpreH52A/cottage/src/recipients.rs:12
  enum cottage::Identity, previously in file /tmp/.tmpreH52A/cottage/src/identity.rs:9
  enum cottage::PreviewFormat, previously in file /tmp/.tmpreH52A/cottage/src/metadata.rs:18

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function cottage::to_decrypted_path, previously in file /tmp/.tmpreH52A/cottage/src/operation.rs:55
  function cottage::diff, previously in file /tmp/.tmpreH52A/cottage/src/diff.rs:16
  function cottage::get_root, previously in file /tmp/.tmpreH52A/cottage/src/project.rs:199
  function cottage::is_encrypted_path, previously in file /tmp/.tmpreH52A/cottage/src/operation.rs:47
  function cottage::clean_dir, previously in file /tmp/.tmpreH52A/cottage/src/clean.rs:30
  function cottage::decrypt_path, previously in file /tmp/.tmpreH52A/cottage/src/dec.rs:139
  function cottage::remove_line_if_present, previously in file /tmp/.tmpreH52A/cottage/src/project.rs:260
  function cottage::status_path, previously in file /tmp/.tmpreH52A/cottage/src/sync.rs:93
  function cottage::clean_path, previously in file /tmp/.tmpreH52A/cottage/src/clean.rs:43
  function cottage::load_identities, previously in file /tmp/.tmpreH52A/cottage/src/identity.rs:88
  function cottage::make_checksum, previously in file /tmp/.tmpreH52A/cottage/src/metadata.rs:61
  function cottage::append_to_gitignore_if_absent, previously in file /tmp/.tmpreH52A/cottage/src/project.rs:325
  function cottage::sync_path, previously in file /tmp/.tmpreH52A/cottage/src/sync.rs:134
  function cottage::to_encrypted_path, previously in file /tmp/.tmpreH52A/cottage/src/operation.rs:37
  function cottage::generate_preview, previously in file /tmp/.tmpreH52A/cottage/src/preview.rs:261
  function cottage::get_project_root, previously in file /tmp/.tmpreH52A/cottage/src/project.rs:217
  function cottage::is_metadata_path, previously in file /tmp/.tmpreH52A/cottage/src/operation.rs:51
  function cottage::load_recipients, previously in file /tmp/.tmpreH52A/cottage/src/recipients.rs:99
  function cottage::verify_checksum, previously in file /tmp/.tmpreH52A/cottage/src/metadata.rs:65
  function cottage::remove_from_gitignore_if_present, previously in file /tmp/.tmpreH52A/cottage/src/project.rs:339
  function cottage::decrypt_into_memory, previously in file /tmp/.tmpreH52A/cottage/src/dec.rs:29
  function cottage::to_metadata_path, previously in file /tmp/.tmpreH52A/cottage/src/operation.rs:42
  function cottage::encrypt_path, previously in file /tmp/.tmpreH52A/cottage/src/enc.rs:211
  function cottage::append_line_if_absent, previously in file /tmp/.tmpreH52A/cottage/src/project.rs:223

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct cottage::Metadata, previously in file /tmp/.tmpreH52A/cottage/src/metadata.rs:45
  struct cottage::SyncOptions, previously in file /tmp/.tmpreH52A/cottage/src/sync.rs:12
  struct cottage::ChecksumMetadata, previously in file /tmp/.tmpreH52A/cottage/src/metadata.rs:11
  struct cottage::OperationResult, previously in file /tmp/.tmpreH52A/cottage/src/operation.rs:17
  struct cottage::DiffOptions, previously in file /tmp/.tmpreH52A/cottage/src/diff.rs:10
  struct cottage::PreviewMetadata, previously in file /tmp/.tmpreH52A/cottage/src/metadata.rs:39
  struct cottage::DecryptOptions, previously in file /tmp/.tmpreH52A/cottage/src/dec.rs:21
  struct cottage::SecretMetadata, previously in file /tmp/.tmpreH52A/cottage/src/metadata.rs:6
  struct cottage::EncryptOptions, previously in file /tmp/.tmpreH52A/cottage/src/enc.rs:23
  struct cottage::CleanOptions, previously in file /tmp/.tmpreH52A/cottage/src/clean.rs:9
  struct cottage::Operation, previously in file /tmp/.tmpreH52A/cottage/src/operation.rs:10
  struct cottage::Project, previously in file /tmp/.tmpreH52A/cottage/src/project.rs:26
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/sayanarijit/cottage/compare/v0.1.10...v0.2.0) - 2026-05-04

### Other

- Privatize crates, fix tests
- Use secrecy types
- Document
- Make things private
- --dry-run, --skip-encryption, --skip-decryption
- Don't allow `run` on dirty paths
- Clarify encryption behavior in README
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).