### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/sayanarijit/cottage/compare/v0.2.1...v0.2.2) - 2026-05-04
+
+### Other
+
+- Improve git attribute contents and docs.
+
 ## [0.2.1](https://github.com/sayanarijit/cottage/compare/v0.2.0...v0.2.1) - 2026-05-04
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cottage"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cottage"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 description = "A modern git based age-encrypted secrets manager for teams."
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `cottage`: 0.2.1 -> 0.2.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/sayanarijit/cottage/compare/v0.2.1...v0.2.2) - 2026-05-04

### Other

- Improve git attribute contents and docs.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).