### PR TITLE
chore: release v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,101 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.3](https://github.com/sayanarijit/cottage/compare/v0.2.2...v0.2.3) - 2026-05-05
 
-## [0.2.2](https://github.com/sayanarijit/cottage/compare/v0.2.1...v0.2.2) - 2026-05-04
+This is to be considered the initial release of the project, and is not expected to be stable. The API may change without a major version bump.
 
-### Other
+Previous releases had a security flaw where it stored the checksum of plain text secrets in the metadata file. While it's difficult, attackers could potentially use this to brute-force the secrets. And hence, the previous releases have been yanked.
 
-- Improve git attribute contents and docs.
+This release removes the checksum from the metadata file.
 
-## [0.2.1](https://github.com/sayanarijit/cottage/compare/v0.2.0...v0.2.1) - 2026-05-04
-
-### Other
-
-- Fix pre-commit hooks
-- Pre-commit hooks
-- Don't auto init
-
-## [0.2.0](https://github.com/sayanarijit/cottage/compare/v0.1.10...v0.2.0) - 2026-05-04
-
-### Other
-
-- Fix images
-- Learn more
-- Privatize crates, fix tests
-- Use secrecy types
-- Document
-- Make things private
-- --dry-run, --skip-encryption, --skip-decryption
-- Don't allow `run` on dirty paths
-- Clarify encryption behavior in README
-
-## [0.1.10](https://github.com/sayanarijit/cottage/compare/v0.1.9...v0.1.10) - 2026-05-03
-
-### Other
-
-- Fix AutoComplete command
-
-## [0.1.9](https://github.com/sayanarijit/cottage/compare/v0.1.8...v0.1.9) - 2026-05-03
-
-### Other
-
-- If ./identity is missing, it will scan ~/.config/cottage/identity and then ~/.ssh
-- Document examples and logo updates
-
-## [0.1.8](https://github.com/sayanarijit/cottage/compare/v0.1.7...v0.1.8) - 2026-05-03
-
-### Other
-
-- Fix cargo binstall ([#15](https://github.com/sayanarijit/cottage/pull/15))
-
-## [0.1.7](https://github.com/sayanarijit/cottage/compare/v0.1.6...v0.1.7) - 2026-05-03
-
-### Other
-
-- Cleanup provance
-- Fix package name
-
-## [0.1.6](https://github.com/sayanarijit/cottage/compare/v0.1.5...v0.1.6) - 2026-05-03
-
-### Other
-
-- Checksum
-- Fix attestation
-
-## [0.1.5](https://github.com/sayanarijit/cottage/compare/v0.1.4...v0.1.5) - 2026-05-03
-
-### Other
-
-- Provance
-- Fix cargo binstall package name
-
-## [0.1.4](https://github.com/sayanarijit/cottage/compare/v0.1.3...v0.1.4) - 2026-05-03
-
-### Other
-
-- Release bins try 4
-
-## [0.1.3](https://github.com/sayanarijit/cottage/compare/v0.1.2...v0.1.3) - 2026-05-03
-
-### Other
-
-- release bin try 3
-
-## [0.1.2](https://github.com/sayanarijit/cottage/compare/v0.1.1...v0.1.2) - 2026-05-03
-
-### Other
-
-- release bins
-
-## [0.1.1](https://github.com/sayanarijit/cottage/compare/v0.1.0...v0.1.1) - 2026-05-03
-
-### Other
-
-- cargo binstall fmt
-- Demo
-- Cottage
-- Cargo pub
-- example -> examples
-- Update GitHub Sponsors username in FUNDING.yml
+If you are upgrading from a previous version, you will need to force re-encrypt (`ctg decrypt --force && ctg encrypt --force`) your secrets with this version to remove the checksum from the metadata file.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cottage"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cottage"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 description = "A modern git based age-encrypted secrets manager for teams."
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `cottage`: 0.2.2 -> 0.2.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.3](https://github.com/sayanarijit/cottage/compare/v0.2.2...v0.2.3) - 2026-05-05

### Other

- Don't checksum decrypted files
- Doc fixes
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).