### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0](https://github.com/sayanarijit/cottage/compare/v0.2.3...v0.3.0) - 2026-05-05
+
+### Added
+
+- feat(code) remove support for passphrase
+- *(acl)* [**breaking**] add basic access control
+
+### Fixed
+
+- *(hash)* [**breaking**] match recipient checksum using only the valid part
+- *(enc)* [**breaking**] verify intended recipients match metadata
+
+### Other
+
+- *(diff)* fix diff tests
+- *(code)* minor cleanups
+- *(deps)* remove rpassword
+- *(acl)* Document the access control feature in readme
+
 ## [0.2.3](https://github.com/sayanarijit/cottage/compare/v0.2.2...v0.2.3) - 2026-05-05
 
 This is to be considered the initial release of the project, and is not expected to be stable. The API may change without a major version bump.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cottage"
-version = "0.2.3"
+version = "0.3.0"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cottage"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2024"
 description = "A modern git based age-encrypted secrets manager for teams."
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `cottage`: 0.2.3 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `cottage` breaking changes

```text
--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  PASSPHRASE_RECIPIENT in file /tmp/.tmpijxMEo/cottage/src/lib.rs:15
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/sayanarijit/cottage/compare/v0.2.3...v0.3.0) - 2026-05-05

### Added

- feat(code) remove support for passphrase
- *(acl)* [**breaking**] add basic access control

### Fixed

- *(hash)* [**breaking**] match recipient checksum using only the valid part
- *(enc)* [**breaking**] verify intended recipients match metadata

### Other

- *(diff)* fix diff tests
- *(code)* minor cleanups
- *(deps)* remove rpassword
- *(acl)* Document the access control feature in readme
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).