### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1](https://github.com/sayanarijit/cottage/compare/v0.4.0...v0.4.1) - 2026-05-06
+
+### Added
+
+- *(docker)* release docker images
+- *(docker)* add docker image
+
+### Fixed
+
+- *(ci)* fix CI ctg verify
+- *(docker)* fix docker image and docs
+
+### Other
+
+- *(ci)* Fix CI verify docs
+- *(readme)* fix gh action example
+- *(badge)* fix readme badge
+- *(action)* update gh action permission with docs
+
 ## [0.4.0](https://github.com/sayanarijit/cottage/compare/v0.3.2...v0.4.0) - 2026-05-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cottage"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cottage"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 description = "A modern git based age-encrypted secrets manager for teams."
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `cottage`: 0.4.0 -> 0.4.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1](https://github.com/sayanarijit/cottage/compare/v0.4.0...v0.4.1) - 2026-05-06

### Added

- *(docker)* release docker images
- *(docker)* add docker image

### Fixed

- *(ci)* fix CI ctg verify
- *(docker)* fix docker image and docs

### Other

- *(ci)* Fix CI verify docs
- *(readme)* fix gh action example
- *(badge)* fix readme badge
- *(action)* update gh action permission with docs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).