### PR TITLE
chore: release v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4](https://github.com/sayanarijit/cottage/compare/v0.4.3...v0.4.4) - 2026-05-08
+
+### Added
+
+- *(pull/push)* add `ctg pull` and `ctg push`
+
+### Fixed
+
+- *(tests)* fix rust tests
+
+### Other
+
+- *(typos)* fix some docs
+
 ## [0.4.3](https://github.com/sayanarijit/cottage/compare/v0.4.2...v0.4.3) - 2026-05-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cottage"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cottage"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 description = "A modern git based age-encrypted secrets manager for teams."
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `cottage`: 0.4.3 -> 0.4.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.4](https://github.com/sayanarijit/cottage/compare/v0.4.3...v0.4.4) - 2026-05-08

### Added

- *(pull/push)* add `ctg pull` and `ctg push`

### Fixed

- *(tests)* fix rust tests

### Other

- *(typos)* fix some docs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).