### PR TITLE
chore: release v0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.4](https://github.com/sayanarijit/cottage/compare/v0.5.3...v0.5.4) - 2026-05-12
+
+### Fixed
+
+- *(precommit)* fix post rewrite checks
+
+### Other
+
+- *(post-pull)* finish the scenario
+
 ## [0.5.3](https://github.com/sayanarijit/cottage/compare/v0.5.2...v0.5.3) - 2026-05-12
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cottage"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cottage"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 description = "A modern git based age-encrypted secrets manager for teams."
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `cottage`: 0.5.3 -> 0.5.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.4](https://github.com/sayanarijit/cottage/compare/v0.5.3...v0.5.4) - 2026-05-12

### Fixed

- *(precommit)* fix post rewrite checks

### Other

- *(post-pull)* finish the scenario
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).