### PR TITLE
feat(cli)!: ctg keygen

### DIFF
--- a/docs/src/3-keys.md
+++ b/docs/src/3-keys.md
@@ -5,6 +5,7 @@ Scenarios for configuring keys for a new or existing git repository:
 1.  [I want to use the auto-generated key pair across multiple projects](#i-want-to-use-the-auto-generated-key-pair-across-multiple-projects)
 2.  [I want to use my existing SSH key pair](#i-want-to-use-my-existing-ssh-key-pair)
 3.  [I want to avoid symlinking my private key in the workspace](#i-want-to-avoid-symlinking-my-private-key-in-the-workspace)
+4.  [I want to generate or re-generate a new key pair in an existing project](#i-want-to-generate-or-re-generate-a-new-key-pair-in-an-existing-project)
 
 ## I want to use the auto-generated key pair across multiple projects
 
@@ -64,4 +65,26 @@ You can also always mention the path to the private key using the `-i / --identi
 >
 > ```stdout
 > removed '.cottage/identity'
+> ```
+
+## I want to generate or re-generate a new key pair in an existing project
+
+If you are setting up keys in an existing cottage project, or want to re-generate existing keys, you can run the `ctg keygen` command:
+
+> ```bash
+> ctg keygen
+> ```
+
+By default, this generates a key pair where the recipient public key file is named after your system username (i.e., `$USER`).
+
+You can customize the name of the public key file in `.cottage/recipients/` using the `-n` or `--name` option:
+
+> ```bash
+> ctg keygen -n myname
+> ```
+
+To force re-generation of the key pair and overwrite any existing identity file, use the `--force` option:
+
+> ```bash
+> ctg keygen -n myname --force
 > ```

--- a/docs/src/6-recipient-decrypt.md
+++ b/docs/src/6-recipient-decrypt.md
@@ -21,17 +21,17 @@ Let's try to decrypt secrets in the cloned repository:
 Right... You need to set up your keys first. Let's add keys first.
 
 > ```bash,test,session=myproject:21
-> ssh-keygen -t rsa -f .cottage/identity -N ""
-> mv -v .cottage/identity.pub .cottage/recipients/newuser
+> ctg keygen -n newuser
+>
+> tree .cottage
 > ```
 >
 > ```stdout
-> Generating public/private rsa key pair.
-> Your identification has been saved in .cottage/identity
-> Your public key has been saved in .cottage/identity.pub
-> The key fingerprint is:
-> ...XXX...
-> renamed '.cottage/identity.pub' -> '.cottage/recipients/newuser'
+> .cottage
+> ├── identity
+> └── recipients
+>     ├── newuser
+>     └── sayanarijit
 > ```
 
 Let's commit and push the changes to the remote repository, so that someone with access (admin) can pull the changes and re-encrypt the secrets for the new key:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -46,6 +46,10 @@ enum Command {
     #[command(name = "init")]
     Init,
 
+    /// Generate or re-generate key-pair in an existing cottage project.
+    #[command(name = "keygen")]
+    Keygen(KeygenArgs),
+
     /// Edit a file and encrypt it.
     #[command(name = "edit", aliases = ["ed"])]
     Edit(EditArgs),
@@ -130,6 +134,18 @@ struct CleanArgs {
     /// Compact output.
     #[arg(long, env = "COTTAGE_COMPACT")]
     compact: bool,
+}
+
+#[derive(clap::Args, Debug, Default)]
+struct KeygenArgs {
+    /// The recipient key file name.
+    /// Defaults to $USER.
+    #[arg(short, long)]
+    name: Option<String>,
+
+    /// Force re-generation of key-pair if it already exists.
+    #[arg(long, short, env = "COTTAGE_FORCE")]
+    force: bool,
 }
 
 #[derive(clap::Args, Debug, Default)]
@@ -991,6 +1007,10 @@ fn run_verify_cmd(proj: &Project, args: VerifyArgs, quiet: bool) -> Result<()> {
     Ok(())
 }
 
+fn run_keygen_cmd(proj: &Project, args: KeygenArgs) -> Result<()> {
+    proj.keygen(args.name, args.force)
+}
+
 fn run_cmd(cmd: Command, verbosity: Verbosity<WarnLevel>) -> Result<()> {
     if let Command::AutoComplete { shell } = cmd {
         return run_complete_cmd(shell);
@@ -1008,6 +1028,7 @@ fn run_cmd(cmd: Command, verbosity: Verbosity<WarnLevel>) -> Result<()> {
 
     match cmd {
         Command::Init | Command::AutoComplete { shell: _ } => Ok(()), // already handled
+        Command::Keygen(args) => run_keygen_cmd(&proj, args),
         Command::Encrypt(args) => run_encrypt_cmd(&proj, args, is_silent),
         Command::Decrypt(args) => run_decrypt_cmd(&proj, args, is_silent),
         Command::Sync(args) => run_sync_cmd(&proj, args, is_silent),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,8 @@ pub(crate) use metadata::{
 };
 pub(crate) use operation::{
     Operation, OperationKind, OperationResult, is_encrypted_path, is_metadata_path, print_result,
-    run_upstream_script, secure_remove_file, to_decrypted_path, to_encrypted_path, to_metadata_path,
+    run_upstream_script, secure_remove_file, to_decrypted_path, to_encrypted_path,
+    to_metadata_path,
 };
 pub(crate) use preview::generate_preview;
 pub(crate) use project::{Project, iter_encrypted, remove_from_gitignore_if_present};

--- a/src/project.rs
+++ b/src/project.rs
@@ -111,7 +111,7 @@ pub struct Project {
 
 impl Project {
     pub fn init() -> Result<Self> {
-        Self::load().or_else(|_| {
+        let proj = Self::load().or_else(|_| {
             log::debug!("project root not found, initializing new project");
 
             let cwd = std::env::current_dir().context("could not get current working directory")?;
@@ -128,7 +128,13 @@ impl Project {
             })?;
             log::debug!("{}: created directory", cottage_dir.display());
             Self::load().context("could not load project after initialization")
-        })
+        })?;
+
+        if !proj.identity_path().exists() && !proj.recipients_path().exists() {
+            keygen(proj.identity_path(), proj.recipients_path(), None)?;
+        }
+
+        Ok(proj)
     }
 
     pub fn load() -> Result<Self> {
@@ -164,50 +170,6 @@ impl Project {
 
         let recipients_path = cottage_dir.join("recipients");
         let identity_path = cottage_dir.join("identity");
-        if !identity_path.exists() && !recipients_path.exists() {
-            let recipient = whoami::username().unwrap_or_else(|_| {
-                SystemTime::now()
-                    .duration_since(SystemTime::UNIX_EPOCH)
-                    .unwrap()
-                    .as_secs()
-                    .to_string()
-            });
-            let recipient_path = recipients_path.join(&recipient);
-            log::debug!(
-                "init: {}: creating new recipient and identity for user {}",
-                recipient_path.display(),
-                recipient
-            );
-
-            let sk = age::x25519::Identity::generate();
-            let pk = sk.to_public();
-
-            std::fs::create_dir_all(&recipients_path).with_context(|| {
-                format!(
-                    "{}: could not create recipients directory",
-                    recipients_path.display()
-                )
-            })?;
-            log::debug!("{}: created directory", recipients_path.display());
-            std::fs::write(&recipient_path, pk.to_string()).with_context(|| {
-                format!(
-                    "{}: could not write recipient file",
-                    recipient_path.display()
-                )
-            })?;
-            log::debug!("{}: wrote file", recipient_path.display());
-            std::fs::write(&identity_path, sk.to_string().expose_secret()).with_context(|| {
-                format!("{}: could not write identity file", identity_path.display())
-            })?;
-            log::debug!("{}: wrote file", identity_path.display());
-
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                std::fs::set_permissions(&identity_path, std::fs::Permissions::from_mode(0o600))?;
-                log::debug!("{}: set permissions to 600", identity_path.display());
-            }
-        };
 
         let git = if root.join(".git").exists() {
             Some(Git {
@@ -282,6 +244,20 @@ impl Project {
 
     pub fn config(&self) -> Option<&ProjectConfig> {
         self.config.as_ref()
+    }
+
+    pub fn keygen(&self, name: Option<String>, force: bool) -> Result<()> {
+        match (self.identity_path().exists(), force) {
+            (true, false) => Err(anyhow!(
+                "{}: identity file already exists, use --force to overwrite",
+                self.relative_to_root(self.identity_path()).display()
+            )),
+            (true, true) => {
+                secure_remove_file(self.identity_path())?;
+                keygen(self.identity_path(), self.recipients_path(), name)
+            }
+            (false, _) => keygen(self.identity_path(), self.recipients_path(), name),
+        }
     }
 
     pub fn resolve_upstream(
@@ -432,6 +408,53 @@ impl Project {
         }
         Ok(())
     }
+}
+
+pub fn keygen(identity_path: &Path, recipients_path: &Path, name: Option<String>) -> Result<()> {
+    let recipient = name.or(whoami::username().ok()).unwrap_or_else(|| {
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            .to_string()
+    });
+
+    let recipient_path = recipients_path.join(&recipient);
+    log::debug!(
+        "init: {}: creating new recipient and identity for user {}",
+        recipient_path.display(),
+        recipient
+    );
+
+    let sk = age::x25519::Identity::generate();
+    let pk = sk.to_public();
+
+    std::fs::create_dir_all(recipients_path).with_context(|| {
+        format!(
+            "{}: could not create recipients directory",
+            recipients_path.display()
+        )
+    })?;
+    log::debug!("{}: created directory", recipients_path.display());
+    std::fs::write(&recipient_path, pk.to_string()).with_context(|| {
+        format!(
+            "{}: could not write recipient file",
+            recipient_path.display()
+        )
+    })?;
+    log::debug!("{}: wrote file", recipient_path.display());
+    std::fs::write(identity_path, sk.to_string().expose_secret())
+        .with_context(|| format!("{}: could not write identity file", identity_path.display()))?;
+    log::debug!("{}: wrote file", identity_path.display());
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(identity_path, std::fs::Permissions::from_mode(0o600))?;
+        log::debug!("{}: set permissions to 600", identity_path.display());
+    }
+
+    Ok(())
 }
 
 pub fn iter_encrypted(path: &Path) -> impl Iterator<Item = walkdir::DirEntry> {

--- a/tests/test_run.rs
+++ b/tests/test_run.rs
@@ -47,3 +47,59 @@ fn test_run_command() {
     assert!(stdout.contains("my secret"));
     assert!(!temp.path().join("secret.txt").exists());
 }
+
+#[test]
+fn test_keygen_command() {
+    let temp = assert_fs::TempDir::new().unwrap();
+    let bin_path = env!("CARGO_BIN_EXE_ctg");
+
+    // Init project
+    Command::new(bin_path)
+        .arg("init")
+        .current_dir(temp.path())
+        .status()
+        .unwrap();
+
+    let identity_path = temp.path().join(".cottage/identity");
+    let user1_recipient_path = temp.path().join(".cottage/recipients/user1");
+    let user2_recipient_path = temp.path().join(".cottage/recipients/user2");
+
+    // Running keygen without --force should fail if identity already exists
+    let output = Command::new(bin_path)
+        .arg("keygen")
+        .arg("-n")
+        .arg("user1")
+        .current_dir(temp.path())
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+
+    // Running keygen with --force should succeed and overwrite
+    let output = Command::new(bin_path)
+        .arg("keygen")
+        .arg("-n")
+        .arg("user1")
+        .arg("--force")
+        .current_dir(temp.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert!(identity_path.exists());
+    assert!(user1_recipient_path.exists());
+
+    // Delete keys
+    std::fs::remove_file(&identity_path).unwrap();
+    std::fs::remove_dir_all(temp.path().join(".cottage/recipients")).unwrap();
+
+    // Running keygen when keys are missing should succeed without --force
+    let output = Command::new(bin_path)
+        .arg("keygen")
+        .arg("-n")
+        .arg("user2")
+        .current_dir(temp.path())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert!(identity_path.exists());
+    assert!(user2_recipient_path.exists());
+}


### PR DESCRIPTION
- Cottage no longer tries to auto-generate keypair in existing project.
- `ctg keygen` can be used to generate keys in an existing cottage project.
- `ctg init` still generates a new keypair in a new cottage project.