### PR TITLE
chore: release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1](https://github.com/sayanarijit/cottage/compare/v0.6.0...v0.6.1) - 2026-06-06
+
+### Added
+
+- *(upstream)* Auto require decrypted secrets from vars
+- *(upstream)* Declare upstream required secrets
+
+### Fixed
+
+- *(plugin)* Fix plugin execution
+- *(clean)* Cleanup temporary decrypted files reliably
+
+### Other
+
+- *(plugin)* Update plugin to use `requires` attr
+- *(config)* Simplify configuration inheritence
+- *(config)* Add more tests for config inheritence
+- Another minor example cleanup
+- Minor cleanup of example
+- *(plugin)* Add working plugin that also serves as example
+
 ## [0.6.0](https://github.com/sayanarijit/cottage/compare/v0.5.6...v0.6.0) - 2026-06-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cottage"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cottage"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 description = "A modern git based age-encrypted secrets manager for teams."
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `cottage`: 0.6.0 -> 0.6.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.1](https://github.com/sayanarijit/cottage/compare/v0.6.0...v0.6.1) - 2026-06-06

### Added

- *(upstream)* Auto require decrypted secrets from vars
- *(upstream)* Declare upstream required secrets

### Fixed

- *(plugin)* Fix plugin execution
- *(clean)* Cleanup temporary decrypted files reliably

### Other

- *(plugin)* Update plugin to use `requires` attr
- *(config)* Simplify configuration inheritence
- *(config)* Add more tests for config inheritence
- Another minor example cleanup
- Minor cleanup of example
- *(plugin)* Add working plugin that also serves as example
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).