### PR TITLE
chore: release v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2](https://github.com/sayanarijit/cottage/compare/v0.6.1...v0.6.2) - 2026-06-06
+
+### Added
+
+- feat!(upstream): Check status pre-requirements decryption
+
+### Fixed
+
+- *(upstream)* Update timestamps post-requirements-decryption
+
+### Other
+
+- format
+- Simplify plugin features description in documentation
+- Improve plugin docs
+- Rearrange KUBE_NAMESPACE and VAULT_MOUNT in config
+- Update required secrets file in cottage.toml
+- Rename upstream from 'myvault' to 'customvault'
+- Fix examples doc
+- minor docs cleanup
+- *(plugin)* Update cottage.toml example docs
+
 ## [0.6.1](https://github.com/sayanarijit/cottage/compare/v0.6.0...v0.6.1) - 2026-06-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,7 +510,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cottage"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cottage"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2024"
 description = "A modern git based age-encrypted secrets manager for teams."
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `cottage`: 0.6.1 -> 0.6.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.2](https://github.com/sayanarijit/cottage/compare/v0.6.1...v0.6.2) - 2026-06-06

### Added

- feat!(upstream): Check status pre-requirements decryption

### Fixed

- *(upstream)* Update timestamps post-requirements-decryption

### Other

- format
- Simplify plugin features description in documentation
- Improve plugin docs
- Rearrange KUBE_NAMESPACE and VAULT_MOUNT in config
- Update required secrets file in cottage.toml
- Rename upstream from 'myvault' to 'customvault'
- Fix examples doc
- minor docs cleanup
- *(plugin)* Update cottage.toml example docs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).