### PR TITLE
chore: release v0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.3](https://github.com/sayanarijit/cottage/compare/v0.6.2...v0.6.3) - 2026-06-10
+
+### Fixed
+
+- pull/push from subdirectory
+
+### Other
+
+- *(deps)* bump log from 0.4.29 to 0.4.30
+- *(deps)* bump assert_fs from 1.1.3 to 1.1.4
+- cleanup redundant docs
+- list the plugins in readme and docs
+- add more plugin examples (mostly AI generated)
+- Add direct vault plugin example
+
 ## [0.6.2](https://github.com/sayanarijit/cottage/compare/v0.6.1...v0.6.2) - 2026-06-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cottage"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cottage"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2024"
 description = "A modern git based age-encrypted secrets manager for teams."
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `cottage`: 0.6.2 -> 0.6.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.3](https://github.com/sayanarijit/cottage/compare/v0.6.2...v0.6.3) - 2026-06-10

### Fixed

- pull/push from subdirectory

### Other

- *(deps)* bump log from 0.4.29 to 0.4.30
- *(deps)* bump assert_fs from 1.1.3 to 1.1.4
- cleanup redundant docs
- list the plugins in readme and docs
- add more plugin examples (mostly AI generated)
- Add direct vault plugin example
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).