### PR TITLE
chore: release v0.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.8](https://github.com/sayanarijit/cottage/compare/v0.6.7...v0.6.8) - 2026-08-15
+
+### Added
+
+- *(ai-safety)* AI agents should ignore sensitive files
+
+### Fixed
+
+- *(doc)* update re-encrypt doc
+- *(gitattribute)* export-ignore -> linguist-generated ([#82](https://github.com/sayanarijit/cottage/pull/82))
+
 ## [0.6.7](https://github.com/sayanarijit/cottage/compare/v0.6.6...v0.6.7) - 2026-08-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,7 +543,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cottage"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cottage"
-version = "0.6.7"
+version = "0.6.8"
 edition = "2024"
 description = "A modern git based age-encrypted secrets manager for teams."
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `cottage`: 0.6.7 -> 0.6.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.8](https://github.com/sayanarijit/cottage/compare/v0.6.7...v0.6.8) - 2026-08-15

### Added

- *(ai-safety)* AI agents should ignore sensitive files

### Fixed

- *(doc)* update re-encrypt doc
- *(gitattribute)* export-ignore -> linguist-generated ([#82](https://github.com/sayanarijit/cottage/pull/82))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).