### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0](https://github.com/sayanarijit/cottage/compare/v0.6.8...v0.7.0) - 2026-08-24
+
+### Added
+
+- *(run --clean)* add ctg run --clean
+- *(plugin)* add cottage plugin for github secrets ([#83](https://github.com/sayanarijit/cottage/pull/83))
+
+### Fixed
+
+- *(docs)* [**breaking**] update docs to clearify the clean behaviour
+- *(--clean)* --clean should always cleanup decrypted files
+
+### Other
+
+- *(example)* update example
+- *(ceps)* update deps
+- *(readme)* include github secrets plugin in readme
+
 ## [0.6.8](https://github.com/sayanarijit/cottage/compare/v0.6.7...v0.6.8) - 2026-08-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,7 +536,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cottage"
-version = "0.6.8"
+version = "0.7.0"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cottage"
-version = "0.6.8"
+version = "0.7.0"
 edition = "2024"
 description = "A modern git based age-encrypted secrets manager for teams."
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `cottage`: 0.6.8 -> 0.7.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.0](https://github.com/sayanarijit/cottage/compare/v0.6.8...v0.7.0) - 2026-08-24

### Added

- *(run --clean)* add ctg run --clean
- *(plugin)* add cottage plugin for github secrets ([#83](https://github.com/sayanarijit/cottage/pull/83))

### Fixed

- *(docs)* [**breaking**] update docs to clearify the clean behaviour
- *(--clean)* --clean should always cleanup decrypted files

### Other

- *(example)* update example
- *(ceps)* update deps
- *(readme)* include github secrets plugin in readme
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).