### PR TITLE
feat(identitystr): Allow passing the private key directly

### DIFF
--- a/docs/src/3-keys.md
+++ b/docs/src/3-keys.md
@@ -57,7 +57,7 @@ If the project-level identity is absent, it will try to load all keys from `~/.c
 
 If that is also absent, it will try to load all keys from `~/.ssh`.
 
-You can also always mention the path to the private key using the `-i / --identity` flag or the `COTTAGE_IDENTITY` environment variable.
+You can also always pass the path to the private key, or the identity string itself, using the `-i / --identity` flag or the `COTTAGE_IDENTITY` environment variable.
 
 > ```bash
 > rm -v .cottage/identity

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -158,10 +158,10 @@ struct EditArgs {
     #[arg(short = 'R', long, env = "COTTAGE_RECIPIENTS_FILE")]
     recipients_file: Vec<PathBuf>,
 
-    /// Use the identity file at PATH. Can be repeated.
+    /// Use the identity file at PATH, or the identity string itself. Can be repeated.
     /// Defaults to .cottage/identity or ~/.config/cottage/identity or ~/.ssh.
     #[arg(short, long, env = "COTTAGE_IDENTITY")]
-    identity: Vec<PathBuf>,
+    identity: Vec<String>,
 
     /// Encrypt to a PEM encoded format.
     #[arg(short, long, env = "COTTAGE_ARMOR")]
@@ -210,10 +210,10 @@ struct EncryptArgs {
     #[arg(short = 'R', long, env = "COTTAGE_RECIPIENTS_FILE")]
     recipients_file: Vec<PathBuf>,
 
-    /// Use the identity file at PATH. Can be repeated.
+    /// Use the identity file at PATH, or the identity string itself. Can be repeated.
     /// Defaults to .cottage/identity or ~/.config/cottage/identity or ~/.ssh.
     #[arg(short, long, env = "COTTAGE_IDENTITY")]
-    identity: Vec<PathBuf>,
+    identity: Vec<String>,
 
     /// Encrypt to a PEM encoded format.
     #[arg(short, long, env = "COTTAGE_ARMOR")]
@@ -258,10 +258,10 @@ struct DecryptArgs {
     #[arg(short = 'R', long, env = "COTTAGE_RECIPIENTS_FILE")]
     recipients_file: Vec<PathBuf>,
 
-    /// Use the identity file at PATH. Can be repeated.
+    /// Use the identity file at PATH, or the identity string itself. Can be repeated.
     /// Defaults to .cottage/identity or ~/.config/cottage/identity or ~/.ssh.
     #[arg(short, long, env = "COTTAGE_IDENTITY")]
-    identity: Vec<PathBuf>,
+    identity: Vec<String>,
 
     /// Skip updating timestamps on decrypted files.
     #[arg(long, env = "COTTAGE_SKIP_TIMESTAMPS")]
@@ -306,10 +306,10 @@ struct RunArgs {
     #[arg(short = 'R', long, env = "COTTAGE_RECIPIENTS_FILE")]
     recipients_file: Vec<PathBuf>,
 
-    /// Use the identity file at PATH. Can be repeated.
+    /// Use the identity file at PATH, or the identity string itself. Can be repeated.
     /// Defaults to .cottage/identity or ~/.config/cottage/identity or ~/.ssh.
     #[arg(short, long, env = "COTTAGE_IDENTITY")]
-    identity: Vec<PathBuf>,
+    identity: Vec<String>,
 
     /// Skip checksum verification and decrypt all files.
     #[arg(long, short, env = "COTTAGE_FORCE")]
@@ -350,10 +350,10 @@ struct EnvArgs {
     #[arg(short = 'F', long)]
     file: Option<PathBuf>,
 
-    /// Use the identity file at PATH. Can be repeated.
+    /// Use the identity file at PATH, or the identity string itself. Can be repeated.
     /// Defaults to .cottage/identity or ~/.config/cottage/identity or ~/.ssh.
     #[arg(short, long, env = "COTTAGE_IDENTITY")]
-    identity: Vec<PathBuf>,
+    identity: Vec<String>,
 
     /// Verify against recipients listed at PATH. Can be repeated.
     /// Defaults to recipients in .cottage/recipients.
@@ -391,10 +391,10 @@ struct SyncArgs {
     #[arg(short = 'R', long, env = "COTTAGE_RECIPIENTS_FILE")]
     recipients_file: Vec<PathBuf>,
 
-    /// Use the identity file at PATH. Can be repeated.
+    /// Use the identity file at PATH, or the identity string itself. Can be repeated.
     /// Defaults to .cottage/identity or ~/.config/cottage/identity or ~/.ssh.
     #[arg(short, long, env = "COTTAGE_IDENTITY")]
-    identity: Vec<PathBuf>,
+    identity: Vec<String>,
 
     /// Encrypt to a PEM encoded format.
     #[arg(short, long, env = "COTTAGE_ARMOR")]
@@ -451,10 +451,10 @@ struct DiffArgs {
     #[arg(short = 'R', long, env = "COTTAGE_RECIPIENTS_FILE")]
     recipients_file: Vec<PathBuf>,
 
-    /// Use the identity file at PATH. Can be repeated.
+    /// Use the identity file at PATH, or the identity string itself. Can be repeated.
     /// Defaults to .cottage/identity or ~/.config/cottage/identity or ~/.ssh.
     #[arg(short, long, env = "COTTAGE_IDENTITY")]
-    identity: Vec<PathBuf>,
+    identity: Vec<String>,
 
     /// Skip checksum verification of encrypted files.
     #[arg(long, env = "COTTAGE_SKIP_VERIFY_ENCRYPTED")]
@@ -535,10 +535,10 @@ struct PullArgs {
     #[arg(short = 'R', long, env = "COTTAGE_RECIPIENTS_FILE")]
     recipients_file: Vec<PathBuf>,
 
-    /// Use the identity file at PATH. Can be repeated.
+    /// Use the identity file at PATH, or the identity string itself. Can be repeated.
     /// Defaults to .cottage/identity or ~/.config/cottage/identity or ~/.ssh.
     #[arg(short, long, env = "COTTAGE_IDENTITY")]
-    identity: Vec<PathBuf>,
+    identity: Vec<String>,
 
     /// Encrypt to a PEM encoded format.
     #[arg(short, long, env = "COTTAGE_ARMOR")]
@@ -581,10 +581,10 @@ struct PushArgs {
     /// The file or dir to push, defaults to project root.
     path: Vec<PathBuf>,
 
-    /// Use the identity file at PATH. Can be repeated.
+    /// Use the identity file at PATH, or the identity string itself. Can be repeated.
     /// Defaults to .cottage/identity or ~/.config/cottage/identity or ~/.ssh.
     #[arg(short, long, env = "COTTAGE_IDENTITY")]
-    identity: Vec<PathBuf>,
+    identity: Vec<String>,
 
     /// Verify against recipients listed at PATH. Can be repeated.
     /// Defaults to recipients in .cottage/recipients.

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -2,7 +2,7 @@ use crate::Project;
 use age::ssh;
 use age::x25519;
 use anyhow::{Context, Result, anyhow};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::str::FromStr;
 
 #[derive(Clone)]
@@ -29,10 +29,8 @@ impl From<Identity> for Box<dyn age::Identity> {
     }
 }
 
-pub fn parse_identity_file(path: &Path) -> Result<Box<dyn Iterator<Item = Identity>>> {
-    log::debug!("{}: parsing identity", path.display());
-    let s = std::fs::read_to_string(path)
-        .with_context(|| format!("{}: could not read identity file", path.display()))?
+pub fn parse_identity_str(s: &str) -> Result<Box<dyn Iterator<Item = Identity>>> {
+    let s = s
         .lines()
         .map(|l| l.trim())
         .filter(|l| !l.is_empty() && !l.starts_with('#'))
@@ -44,15 +42,23 @@ pub fn parse_identity_file(path: &Path) -> Result<Box<dyn Iterator<Item = Identi
         for line in s.lines() {
             let identity = age::x25519::Identity::from_str(line)
                 .map_err(|e| anyhow!("{}: could not parse age identity", e))?;
-            log::debug!("{}: parsed age identity", path.display());
+            log::debug!("parsed age identity");
             ids.push(Identity::X25519(identity));
         }
         return Ok(Box::new(ids.into_iter()));
     }
 
-    let identity = age::ssh::Identity::from_buffer(s.as_bytes(), None)?;
-    log::debug!("{}: parsed ssh identity", path.display());
+    let identity = age::ssh::Identity::from_buffer(s.as_bytes(), None)
+        .map_err(|e| anyhow!("{}: could not parse ssh identity", e))?;
+    log::debug!("parsed ssh identity");
     Ok(Box::new(std::iter::once(Identity::Ssh(identity))))
+}
+
+pub fn parse_identity_file(path: &Path) -> Result<Box<dyn Iterator<Item = Identity>>> {
+    log::debug!("{}: parsing identity", path.display());
+    let s = std::fs::read_to_string(path)
+        .with_context(|| format!("{}: could not read identity file", path.display()))?;
+    parse_identity_str(&s)
 }
 
 pub fn parse_identities_dir(path: &Path) -> Box<dyn Iterator<Item = Identity>> {
@@ -101,7 +107,7 @@ pub fn parse_identities_path(path: &Path) -> Option<Box<dyn Iterator<Item = Iden
 
 pub fn load_identities(
     proj: &Project,
-    identities: Vec<PathBuf>,
+    identities: Vec<String>,
 ) -> Box<dyn Iterator<Item = Identity>> {
     log::debug!("loading identities");
     if identities.is_empty() {
@@ -140,11 +146,26 @@ pub fn load_identities(
         log::debug!("{} identities provided, parsing", identities.len());
         let iter = identities
             .into_iter()
-            .filter_map(|p| match parse_identity_file(&p) {
-                Ok(identities) => Some(identities),
-                Err(e) => {
-                    log::warn!("skipped: {}: {}", p.display(), e);
-                    None
+            .filter_map(|item| {
+                let path = Path::new(&item);
+                if path.is_file() {
+                    match parse_identity_file(path) {
+                        Ok(identities) => Some(identities),
+                        Err(e) => {
+                            log::warn!("skipped: {}: {}", path.display(), e);
+                            None
+                        }
+                    }
+                } else if path.is_dir() {
+                    Some(parse_identities_dir(path))
+                } else {
+                    match parse_identity_str(&item) {
+                        Ok(identities) => Some(identities),
+                        Err(e) => {
+                            log::warn!("skipped: could not parse identity: {}", e);
+                            None
+                        }
+                    }
                 }
             })
             .flatten();

--- a/src/tests/test_identity.rs
+++ b/src/tests/test_identity.rs
@@ -1,6 +1,7 @@
 use crate::Project;
 use crate::identity::{
     Identity, load_identities, parse_identities_dir, parse_identities_path, parse_identity_file,
+    parse_identity_str,
 };
 use age::secrecy::ExposeSecret;
 use assert_fs::prelude::*;
@@ -76,6 +77,43 @@ fn test_parse_identity_file_ssh() {
     file.write_str(TEST_SSH_KEY).unwrap();
 
     let mut identities = parse_identity_file(file.path()).unwrap();
+    let first = identities.next().unwrap();
+    assert!(matches!(first, Identity::Ssh(_)));
+    assert!(identities.next().is_none());
+}
+
+#[test]
+fn test_parse_identity_str_single_age() {
+    let sk = age::x25519::Identity::generate();
+    let key_str = sk.to_string().expose_secret().to_string();
+
+    let mut identities = parse_identity_str(&key_str).unwrap();
+    let first = identities.next().unwrap();
+    assert!(matches!(first, Identity::X25519(_)));
+    assert!(identities.next().is_none());
+}
+
+#[test]
+fn test_parse_identity_str_multiple_age() {
+    let sk1 = age::x25519::Identity::generate();
+    let sk2 = age::x25519::Identity::generate();
+    let content = format!(
+        "# First key\n{}\n\n# Second key\n  {}  \n",
+        sk1.to_string().expose_secret(),
+        sk2.to_string().expose_secret()
+    );
+
+    let mut identities = parse_identity_str(&content).unwrap();
+    let first = identities.next().unwrap();
+    assert!(matches!(first, Identity::X25519(_)));
+    let second = identities.next().unwrap();
+    assert!(matches!(second, Identity::X25519(_)));
+    assert!(identities.next().is_none());
+}
+
+#[test]
+fn test_parse_identity_str_ssh() {
+    let mut identities = parse_identity_str(TEST_SSH_KEY).unwrap();
     let first = identities.next().unwrap();
     assert!(matches!(first, Identity::Ssh(_)));
     assert!(identities.next().is_none());
@@ -161,9 +199,68 @@ fn test_load_identities_explicit() {
     file1.write_str(sk1.to_string().expose_secret()).unwrap();
     file2.write_str(sk2.to_string().expose_secret()).unwrap();
 
-    let paths = vec![file1.path().to_path_buf(), file2.path().to_path_buf()];
+    let paths = vec![
+        file1.path().to_str().unwrap().to_string(),
+        file2.path().to_str().unwrap().to_string(),
+    ];
     let identities: Vec<Identity> = load_identities(&proj, paths).collect();
     assert_eq!(identities.len(), 2);
+}
+
+#[test]
+fn test_load_identities_string_age() {
+    let temp = assert_fs::TempDir::new().unwrap();
+    let proj = Project::generate_test_project(temp.path());
+
+    let sk = age::x25519::Identity::generate();
+    let key_str = sk.to_string().expose_secret().to_string();
+
+    let identities: Vec<Identity> = load_identities(&proj, vec![key_str]).collect();
+    assert_eq!(identities.len(), 1);
+    assert!(matches!(identities[0], Identity::X25519(_)));
+}
+
+#[test]
+fn test_load_identities_string_ssh() {
+    let temp = assert_fs::TempDir::new().unwrap();
+    let proj = Project::generate_test_project(temp.path());
+
+    let identities: Vec<Identity> =
+        load_identities(&proj, vec![TEST_SSH_KEY.to_string()]).collect();
+    assert_eq!(identities.len(), 1);
+    assert!(matches!(identities[0], Identity::Ssh(_)));
+}
+
+#[test]
+fn test_load_identities_mixed() {
+    let temp = assert_fs::TempDir::new().unwrap();
+    let proj = Project::generate_test_project(temp.path());
+
+    let sk1 = age::x25519::Identity::generate();
+    let file1 = temp.child("key1");
+    file1.write_str(sk1.to_string().expose_secret()).unwrap();
+
+    let sk2 = age::x25519::Identity::generate();
+    let key_str2 = sk2.to_string().expose_secret().to_string();
+
+    let items = vec![
+        file1.path().to_str().unwrap().to_string(),
+        key_str2,
+        TEST_SSH_KEY.to_string(),
+    ];
+
+    let identities: Vec<Identity> = load_identities(&proj, items).collect();
+    assert_eq!(identities.len(), 3);
+}
+
+#[test]
+fn test_load_identities_invalid_string() {
+    let temp = assert_fs::TempDir::new().unwrap();
+    let proj = Project::generate_test_project(temp.path());
+
+    let items = vec!["invalid-key-or-path".to_string()];
+    let identities: Vec<Identity> = load_identities(&proj, items).collect();
+    assert_eq!(identities.len(), 0);
 }
 
 #[test]

--- a/tests/test_run.rs
+++ b/tests/test_run.rs
@@ -682,3 +682,111 @@ fn test_run_auto_clean_only_when_not_present_or_clean_flag() {
         "secret2.txt should be cleaned after project-wide clean"
     );
 }
+
+#[test]
+fn test_identity_as_string_flag() {
+    let temp = assert_fs::TempDir::new().unwrap();
+    let bin_path = env!("CARGO_BIN_EXE_ctg");
+
+    // Init
+    Command::new(bin_path)
+        .arg("init")
+        .current_dir(temp.path())
+        .status()
+        .unwrap();
+
+    // Read identity string and remove identity file
+    let identity_file = temp.path().join(".cottage/identity");
+    let id_str = std::fs::read_to_string(&identity_file).unwrap();
+    std::fs::remove_file(&identity_file).unwrap();
+
+    // Create secret
+    temp.child("secret.txt")
+        .write_str("my secret string key")
+        .unwrap();
+
+    // Encrypt
+    let enc_output = Command::new(bin_path)
+        .arg("encrypt")
+        .arg("secret.txt")
+        .current_dir(temp.path())
+        .output()
+        .unwrap();
+    assert!(enc_output.status.success());
+
+    // Delete decrypted secret
+    std::fs::remove_file(temp.path().join("secret.txt")).unwrap();
+
+    // Decrypt without identity should fail
+    let dec_fail = Command::new(bin_path)
+        .arg("decrypt")
+        .arg("secret.txt.cott.age")
+        .current_dir(temp.path())
+        .output()
+        .unwrap();
+    assert!(!dec_fail.status.success());
+
+    // Decrypt with -i <id_str> should succeed
+    let dec_success = Command::new(bin_path)
+        .arg("decrypt")
+        .arg("secret.txt.cott.age")
+        .arg("-i")
+        .arg(&id_str)
+        .current_dir(temp.path())
+        .output()
+        .unwrap();
+    assert!(dec_success.status.success());
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("secret.txt")).unwrap(),
+        "my secret string key"
+    );
+}
+
+#[test]
+fn test_identity_as_string_env() {
+    let temp = assert_fs::TempDir::new().unwrap();
+    let bin_path = env!("CARGO_BIN_EXE_ctg");
+
+    // Init
+    Command::new(bin_path)
+        .arg("init")
+        .current_dir(temp.path())
+        .status()
+        .unwrap();
+
+    // Read identity string and remove identity file
+    let identity_file = temp.path().join(".cottage/identity");
+    let id_str = std::fs::read_to_string(&identity_file).unwrap();
+    std::fs::remove_file(&identity_file).unwrap();
+
+    // Create secret
+    temp.child("secret.txt")
+        .write_str("my secret env key")
+        .unwrap();
+
+    // Encrypt
+    let enc_output = Command::new(bin_path)
+        .arg("encrypt")
+        .arg("secret.txt")
+        .current_dir(temp.path())
+        .output()
+        .unwrap();
+    assert!(enc_output.status.success());
+
+    // Delete decrypted secret
+    std::fs::remove_file(temp.path().join("secret.txt")).unwrap();
+
+    // Decrypt with COTTAGE_IDENTITY=<id_str> should succeed
+    let dec_success = Command::new(bin_path)
+        .arg("decrypt")
+        .arg("secret.txt.cott.age")
+        .env("COTTAGE_IDENTITY", &id_str)
+        .current_dir(temp.path())
+        .output()
+        .unwrap();
+    assert!(dec_success.status.success());
+    assert_eq!(
+        std::fs::read_to_string(temp.path().join("secret.txt")).unwrap(),
+        "my secret env key"
+    );
+}


### PR DESCRIPTION
Using the COTTAGE_IDENTITY or --identity flag, users can now pass the private key directly. This is helpful in CI/CD environments.