### PR TITLE
chore: release v0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.3](https://github.com/sayanarijit/cottage/compare/v0.7.2...v0.7.3) - 2026-08-28
+
+### Other
+
+- *(docs)* fix docs for ctg run and ctgx
+- *(docs)* update .gitattributes docs
+- *(docs)* add vim/nvim demo
+- *(doc)* add more plugins
+
 ## [0.7.2](https://github.com/sayanarijit/cottage/compare/v0.7.1...v0.7.2) - 2026-08-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,7 +536,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cottage"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "age",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cottage"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2024"
 description = "A modern git based age-encrypted secrets manager for teams."
 readme = "README.md"


### PR DESCRIPTION



## 🤖 New release

* `cottage`: 0.7.2 -> 0.7.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.3](https://github.com/sayanarijit/cottage/compare/v0.7.2...v0.7.3) - 2026-08-28

### Other

- *(docs)* fix docs for ctg run and ctgx
- *(docs)* update .gitattributes docs
- *(docs)* add vim/nvim demo
- *(doc)* add more plugins
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).